### PR TITLE
"Memory Loading" and Refactor Operations Layer to be Singleton

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -2,7 +2,8 @@ var express = require('express');
 
 var api = require('./routes/api')
 var bodyParser = require('body-parser')
-var cors = require('cors')
+var cors = require('cors');
+const { OperationsLayer } = require('./operations');
 
 var app = express();
 const PORT = 4000;
@@ -17,6 +18,7 @@ app.get('/', (req, res) => {
 })
 
 app.listen(PORT, () => {
+  new OperationsLayer()
   console.log("Listening...")
 })
 

--- a/server/operations.js
+++ b/server/operations.js
@@ -6,15 +6,44 @@ File that stores neighborhoodList in memory. Performs all CRUD operations on nei
 
 const csv = require('./csv')
 
-/*
+let isLoaded = false
+let neighborhoodList = []
+class OperationsLayer {
+	//Singleton constructor. If data already loaded, then return the list. Otherwise, load the list.
+	constructor() {
+		if(!isLoaded) {
+			neighborhoodList = csv.load()
+			isLoaded = true
+		}
+		return neighborhoodList
+	}
+
+	/*
 	Function to get the entire NeighborhoodList array from the csv.
 	TODO(?): Figure out a way to store the neighborhoodList in memory so that we don't have to parse the csv file
 		every time we want to access data. load() function doesn't take that much time, so might not be worth the effort.
-*/
-function getNeighborhoodList() {
-	return csv.load();
+	*/
+	static getNeighborhoodList() {
+		return neighborhoodList
+	}
+
+	/*
+	Test function to see filtering in action
+	*/
+	static filterByAll(constraintArray) {
+		if(!isLoaded) initializeDataLayer();
+		// console.log(constraintArray)
+		const newList = neighborhoodList
+		.filter( element => element.median_value >= constraintArray.minMedianHousePrice)
+		.filter( element => element.median_value <= constraintArray.maxMedianHousePrice)
+		.filter( element => element.latitude >= constraintArray.minLatitude)
+		.filter( element => element.latitude <= constraintArray.maxLatitude)
+		.filter( element => element.longitude >= constraintArray.minLongitude)
+		.filter( element => element.longitude <= constraintArray.maxLongitude)
+		return newList
+	}
+	
 }
 
 //TODO: Add CRUD operators to modify individual rows in the neighborhoodList
-
-exports.getNeighborhoodList = getNeighborhoodList;
+exports.OperationsLayer = OperationsLayer

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const operations = require('../operations');
+const { OperationsLayer } = require('../operations')
 const analytics = require('../analytics');
 const router = express.Router()
 
@@ -11,7 +11,7 @@ router.post('/test', (req, res) => {
 
 router.get('/neighborhoodList', (req, res) => {
     //console.log(req.body)
-    res.send(operations.getNeighborhoodList());
+    res.send(new OperationsLayer());
 })
 
 router.get('/medianValueRange', (req, res) => {

--- a/server/test/apiTest.js
+++ b/server/test/apiTest.js
@@ -2,6 +2,7 @@ const chai = require("chai")
 const csv = require('../csv')
 const { expect, assert } = require("chai")
 const chaiHttp = require("chai-http")
+const { OperationsLayer } = require("../operations")
 
 chai.use(require('chai-json'))
 chai.use(chaiHttp)
@@ -25,7 +26,7 @@ describe("Testing API calls", () => {
               })
     })
     it("Should receive the full neighborhoodList array after GET to /api/neighborhoodList", () => {
-	    const csvNeighborhoodList = csv.load();
+	    const csvNeighborhoodList = new OperationsLayer()
 
         chai.request("http://localhost:4000")
             .get("/api/neighborhoodList")

--- a/server/test/csvTest.js
+++ b/server/test/csvTest.js
@@ -1,8 +1,9 @@
 const csv = require('../csv')
 const { expect } = require('chai')
+const { OperationsLayer } = require('../operations')
 
 describe("CSV loading and reading", () => {
-    const data = csv.load()
+    const data = new OperationsLayer()
     it("Should read in exactly 20640 rows", () => {
         expect(data.length).to.be.equal(20640)
     })

--- a/server/test/operationsTest.js
+++ b/server/test/operationsTest.js
@@ -1,15 +1,10 @@
-const operations = require('../operations');
 const csv = require('../csv');
 const { expect } = require('chai');
+const { OperationsLayer } = require('../operations');
 
 describe("operations.getNeighborhoodList function", () => {
-	const operationsNeighborhoodList = operations.getNeighborhoodList();
-	const csvNeighborhoodList = csv.load();
+	const operationsNeighborhoodList = new OperationsLayer();
 
-	//operationsNeighborhoodList should be identical to the one returned by the load() function
-	it("Should return an exact copy of the csv neighborhoodList", () => {
-        expect(operationsNeighborhoodList).to.eql(csvNeighborhoodList); //deep equality assertion
-    })
     it("Should read in exactly 20640 rows", () => {
         expect(operationsNeighborhoodList.length).to.be.equal(20640);
     })


### PR DESCRIPTION
## Major changes

I decided to refactor the operations layer to be more closely aligned with our current needs. operations.js now exports a single class, `OperationsLayer`, which is a singleton. The first run of this class will load the CSV file (with a default in app.js), with subsequent calls simply returning the list. This was done in part due to future plans to incorporate an ID property to neighborhood instances, and loading the data would mess up deep equality checks.

Thus, **should the PR merge (and I argue even before), usage of `csv.load` should not be done at all.** Unfortunately, there are few options within JS to close off access to a property unless we want to couple `operations.js` and `csv.js`, which I would prefer not to.

Unfortunately, this means the removal of a unit test that involves deep equality checking between imported data and the file itself. I'm personally fine with this change as I expect the operations layer to be our "single source of truth" anyways, but I'm curious to hear what you all think.

The PR passes all (now 37) tests, though they have been modified to accommodate this new pattern.
![image](https://user-images.githubusercontent.com/13594022/164123216-95673143-b1f1-4f07-a4f0-8081f62d1495.png)
