### PR TITLE
Crud api calls

### DIFF
--- a/server/operations.js
+++ b/server/operations.js
@@ -40,6 +40,22 @@ class OperationsLayer {
 		.filter( element => element.longitude <= constraintArray.maxLongitude)
 		return newList
 	}
+	/*
+	Delete a neighborhood with the specified id
+	*/
+	static deleteNeighborhood(id) {
+		if(!isLoaded) initializeDataLayer();
+
+		// Search through neighborhoodList for the neighborhood with the given id
+		for(let i = 0; i < neighborhoodList.length; i++) {
+			if(neighborhoodList[i].id == id){
+				//delete the neighborhood at index location i
+				neighborhoodList.splice(i, 1);
+				return 0;
+			}	
+		}
+		return -1;
+	}
 	
 }
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -26,7 +26,7 @@ router.post('/getFilteredData', (req, res) => {
 
 /*
 API call for the create function in the operations layer.
-req: An data array with 15 numbers that can be passed into the neighborhood constructor.
+req: An array with 15 numbers that can be passed into the neighborhood constructor.
 res: string message saying whether or not create operation was successful.
 */
 router.post('/cards', (req, res) => {
@@ -56,20 +56,18 @@ router.delete('/cards', (req, res) => {
 
 /*
 API call for the update function in the operations layer.
-req: 
-    1) The id of the neighborhood to update within the neighborhoodList.
-    2) The column number to update (a number from 0 to 13)
-    3) The value to replace it with
+req: An array of the 15 values needed to for the neighborhood constructor.
+    id value within the array will be the one that will be updated in the NeighborhoodList.
 res: string message saying whether or not delete operation was successful.
 */
 router.patch('/cards', (req, res) => {
     console.log(req.body)
     // result var store operation status. 0 means success, -1 means failure
-    var result = OperationsLayer.update(req.body[0], req.body[1], req.body[2])
+    var result = OperationsLayer.update(req.body)
     if (result == 0)
-        res.json("Successfully updated neighborhood with id: " + req.body[0] + ", at column: " + req.body[1] + ", with value: " + req.body[2])
+        res.json("Successfully updated neighborhood with id: " + req.body.id)
     else
-        res.json("ERROR: unable to update neighborhood with id of " + req.body[0])
+        res.json("ERROR: unable to update neighborhood with id: " + req.body.id)
 })
 
 module.exports = router

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -24,4 +24,52 @@ router.post('/getFilteredData', (req, res) => {
     res.json(result)
 })
 
+/*
+API call for the create function in the operations layer.
+req: An data array with 15 numbers that can be passed into the neighborhood constructor.
+res: string message saying whether or not create operation was successful.
+*/
+router.post('/create', (req, res) => {
+    console.log(req.body)
+    // result var store operation status. 0 means success, -1 means failure
+    var result = OperationsLayer.create(req.body)
+    if (result == 0)
+        res.json("Successfully created new neighborhood")
+    else
+        res.json("ERROR: unable to create neighborhood with the given information")
+})
+
+/*
+API call for the delete function in the operations layer.
+req: The id of the neighborhood to delete within the neighborhoodList.
+res: string message saying whether or not delete operation was successful.
+*/
+router.post('/delete', (req, res) => {
+    console.log(req.body)
+    // result var store operation status. 0 means success, -1 means failure
+    var result = OperationsLayer.delete(req.body)
+    if (result == 0)
+        res.json("Successfully deleted neighborhood with id: " + req.body)
+    else
+        res.json("ERROR: unable to delete neighborhood with id of " + req.body)
+})
+
+/*
+API call for the update function in the operations layer.
+req: 
+    1) The id of the neighborhood to update within the neighborhoodList.
+    2) The column number to update (a number from 0 to 13)
+    3) The value to replace it with
+res: string message saying whether or not delete operation was successful.
+*/
+router.post('/update', (req, res) => {
+    console.log(req.body)
+    // result var store operation status. 0 means success, -1 means failure
+    var result = OperationsLayer.update(req.body[0], req.body[1], req.body[2])
+    if (result == 0)
+        res.json("Successfully updated neighborhood with id: " + req.body[0] + ", at column: " + req.body[1] + ", with value: " + req.body[2])
+    else
+        res.json("ERROR: unable to update neighborhood with id of " + req.body[0])
+})
+
 module.exports = router

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -29,7 +29,7 @@ API call for the create function in the operations layer.
 req: An data array with 15 numbers that can be passed into the neighborhood constructor.
 res: string message saying whether or not create operation was successful.
 */
-router.post('/create', (req, res) => {
+router.post('/cards', (req, res) => {
     console.log(req.body)
     // result var store operation status. 0 means success, -1 means failure
     var result = OperationsLayer.create(req.body)
@@ -44,14 +44,14 @@ API call for the delete function in the operations layer.
 req: The id of the neighborhood to delete within the neighborhoodList.
 res: string message saying whether or not delete operation was successful.
 */
-router.post('/delete', (req, res) => {
+router.delete('/cards', (req, res) => {
     console.log(req.body)
     // result var store operation status. 0 means success, -1 means failure
-    var result = OperationsLayer.delete(req.body)
+    var result = OperationsLayer.deleteNeighborhood(req.body.id)
     if (result == 0)
-        res.json("Successfully deleted neighborhood with id: " + req.body)
+        res.json("Successfully deleted neighborhood with id: " + req.body.id)
     else
-        res.json("ERROR: unable to delete neighborhood with id of " + req.body)
+        res.json("ERROR: unable to delete neighborhood with id of " + req.body.id)
 })
 
 /*
@@ -62,7 +62,7 @@ req:
     3) The value to replace it with
 res: string message saying whether or not delete operation was successful.
 */
-router.post('/update', (req, res) => {
+router.patch('/cards', (req, res) => {
     console.log(req.body)
     // result var store operation status. 0 means success, -1 means failure
     var result = OperationsLayer.update(req.body[0], req.body[1], req.body[2])

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -11,7 +11,7 @@ router.post('/test', (req, res) => {
 
 router.post('/neighborhoodList', (req, res) => {
     console.log(req.body)
-    var jsonString = JSON.stringify(new OperationsLayer());
+    var jsonString = JSON.stringify(OperationsLayer.getNeighborhoodList());
     var jsonParse = JSON.parse(jsonString)
     //console.log(req.body)
     res.json(jsonParse);

--- a/server/test/apiTest.js
+++ b/server/test/apiTest.js
@@ -10,7 +10,6 @@ chai.use(chaiHttp)
 
 describe("api/cards using router.delete", () => {
     it("Should return successful delete message after deleting", () => {
-        //TODO: Add additional filters to the req once those filters are added to /api/getFilteredData
         let req = {
             "id": "10"
         }
@@ -25,7 +24,6 @@ describe("api/cards using router.delete", () => {
             })
     })
     it("Should return error message if delete failed", () => {
-        //TODO: Add additional filters to the req once those filters are added to /api/getFilteredData
         let req = {
             "id": "-1"
         }

--- a/server/test/apiTest.js
+++ b/server/test/apiTest.js
@@ -8,6 +8,41 @@ const analytics = require('../analytics');
 chai.use(require('chai-json'))
 chai.use(chaiHttp)
 
+describe("api/cards using router.delete", () => {
+    it("Should return successful delete message after deleting", () => {
+        //TODO: Add additional filters to the req once those filters are added to /api/getFilteredData
+        let req = {
+            "id": "10"
+        }
+
+        chai.request("http://localhost:4000")
+            .delete("/api/cards")
+            .send(req)
+            .end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                expect(res.body).to.be.equal("Successfully deleted neighborhood with id: " + req.id)
+            })
+    })
+    it("Should return error message if delete failed", () => {
+        //TODO: Add additional filters to the req once those filters are added to /api/getFilteredData
+        let req = {
+            "id": "-1"
+        }
+
+        chai.request("http://localhost:4000")
+            .delete("/api/cards")
+            .send(req)
+            .end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                expect(res.body).to.be.equal("ERROR: unable to delete neighborhood with id of " + req.id)
+            })
+    })
+
+
+})
+
 describe("Testing API calls", () => {
     it("Should receive {\"first\": \"John\", \"last\": \"Doe\"} after POST to /api/test", () => {
         const dummyData = {
@@ -34,8 +69,8 @@ describe("Testing API calls", () => {
             .end((err, res) => {
                 expect(err).to.be.null
                 expect(res).to.be.json
-                //expect(res.body.length).to.be.equal(OperationsLayer.getNeighborhoodList().length)
-                //expect(res.body).to.eql(OperationsLayer.getNeighborhoodList()) //assert deep equality
+                expect(res.body.length).to.be.equal(OperationsLayer.getNeighborhoodList().length)
+                expect(res.body).to.eql(OperationsLayer.getNeighborhoodList()) //assert deep equality
             })
     })
     it("Should receive a filtered neighborhoodList array after POST to /api/getFilteredData", () => {

--- a/server/test/apiTest.js
+++ b/server/test/apiTest.js
@@ -27,15 +27,15 @@ describe("Testing API calls", () => {
             })
     })
     it("Should receive the full neighborhoodList array after POST to /api/neighborhoodList", () => {
-
+        
         chai.request("http://localhost:4000")
             .post("/api/neighborhoodList")
             .send()
             .end((err, res) => {
                 expect(err).to.be.null
                 expect(res).to.be.json
-                expect(res.body.length).to.be.equal(OperationsLayer.getNeighborhoodList().length)
-                expect(res.body).to.eql(OperationsLayer.getNeighborhoodList()) //assert deep equality
+                //expect(res.body.length).to.be.equal(OperationsLayer.getNeighborhoodList().length)
+                //expect(res.body).to.eql(OperationsLayer.getNeighborhoodList()) //assert deep equality
             })
     })
     it("Should receive a filtered neighborhoodList array after POST to /api/getFilteredData", () => {

--- a/server/test/operationsTest.js
+++ b/server/test/operationsTest.js
@@ -22,7 +22,7 @@ describe("operations.deleteNeighborhood function", () => {
     
     //OperationsLayer.deleteNeighborhood(10); // Delete the neighborhood with an id of 10
     
-    it("LengthAfterDelete should be 1 less than LengthBefore Delete", () => {
+    it("LengthAfterDelete should be 1 less than LengthBeforeDelete", () => {
         lengthBeforeDelete = OperationsLayer.getNeighborhoodList().length; // Length of the neighborhoodList before a row is deleted
         deleteCode = OperationsLayer.deleteNeighborhood(10); // Delete id 10 and return 0 if successful
         lengthAfterDelete = OperationsLayer.getNeighborhoodList().length;  // Length of the neighborhoodList after a row is deleted

--- a/server/test/operationsTest.js
+++ b/server/test/operationsTest.js
@@ -3,16 +3,37 @@ const { expect } = require('chai');
 const { OperationsLayer } = require('../operations');
 
 describe("operations.getNeighborhoodList function", () => {
-	const operationsNeighborhoodList = new OperationsLayer();
+	//const operationsNeighborhoodList = new OperationsLayer();
 
     it("Should read in exactly 20640 rows", () => {
-        expect(operationsNeighborhoodList.length).to.be.equal(20640);
+        expect(OperationsLayer.getNeighborhoodList().length).to.be.equal(20640);
     })
     it("Should have a value of 42 in the 9th entry, median_age attribute", () => {
         /*
             Note: This is technically wrong in the sense that the values are NOT typed as numbers.
                     But that's just JS things lmao
         */
-        expect(operationsNeighborhoodList[8]["median_age"]).to.be.equal('42');
+        expect(OperationsLayer.getNeighborhoodList()[8]["median_age"]).to.be.equal('42');
+    })
+});
+
+describe("operations.deleteNeighborhood function", () => {
+	//const operationsNeighborhoodList = new OperationsLayer();
+    
+    //OperationsLayer.deleteNeighborhood(10); // Delete the neighborhood with an id of 10
+    
+    it("LengthAfterDelete should be 1 less than LengthBefore Delete", () => {
+        lengthBeforeDelete = OperationsLayer.getNeighborhoodList().length; // Length of the neighborhoodList before a row is deleted
+        deleteCode = OperationsLayer.deleteNeighborhood(10); // Delete id 10 and return 0 if successful
+        lengthAfterDelete = OperationsLayer.getNeighborhoodList().length;  // Length of the neighborhoodList after a row is deleted
+
+        expect(deleteCode).to.be.equal(0);
+        expect(lengthAfterDelete).to.be.equal(lengthBeforeDelete - 1);
+    })
+    it("Should fail to delete neighborhood with id -1 and return -1", () => {
+        expect(OperationsLayer.deleteNeighborhood(-1)).to.be.equal(-1);
+    })
+    it("Should fail to delete neighborhood with id 10 and return -1", () => {
+        expect(OperationsLayer.deleteNeighborhood(10)).to.be.equal(-1);
     })
 });

--- a/server/test/operationsTest.js
+++ b/server/test/operationsTest.js
@@ -3,7 +3,6 @@ const { expect } = require('chai');
 const { OperationsLayer } = require('../operations');
 
 describe("operations.getNeighborhoodList function", () => {
-	//const operationsNeighborhoodList = new OperationsLayer();
 
     it("Should read in exactly 20640 rows", () => {
         expect(OperationsLayer.getNeighborhoodList().length).to.be.equal(20640);
@@ -18,9 +17,6 @@ describe("operations.getNeighborhoodList function", () => {
 });
 
 describe("operations.deleteNeighborhood function", () => {
-	//const operationsNeighborhoodList = new OperationsLayer();
-    
-    //OperationsLayer.deleteNeighborhood(10); // Delete the neighborhood with an id of 10
     
     it("LengthAfterDelete should be 1 less than LengthBeforeDelete", () => {
         lengthBeforeDelete = OperationsLayer.getNeighborhoodList().length; // Length of the neighborhoodList before a row is deleted


### PR DESCRIPTION
Implemented the api endpoints for the DELETE, REPLACE, and CREATE operations. Right now, I can only be certain that the DELETE api call works properly. I will test the REPLACE and CREATE api calls more extensively after their function has been created in the operations layer.

This merge also contains Garrett's implementation of the Delete function in the operations layer. I merged his work into thsi branch so I could make double sure the OperationsLayer was working as intended.

NOTE: in the test runner, we create an OperationsLayer that is separate from the one created by the server OperationsLayer. This is only an issue for running unit tests, but shouldn't be an issue when running unit tests. I got around this by mimicing delete operations between the two operations layers when doing API calls to that they believe they match up.