### PR TITLE
Successfully integrated CRUD api calls into UI

### DIFF
--- a/client/src/components/AddCard.js
+++ b/client/src/components/AddCard.js
@@ -10,6 +10,7 @@ class AddCard extends Component {
             _median_value: 0,
             _median_income: 0,
             _median_age: 0,
+            _total_rooms: 0,
             _total_bedrooms: 0,
             _population: 0,
             _households: 0,

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -5,11 +5,13 @@ const router = express.Router()
 
 //Handle POST request coming from api/test. Currently just logs the body, and then sends that back.
 router.post('/test', (req, res) => {
+    console.log("api/test call:")
     console.log(req.body)
     res.json(req.body)
 })
 
 router.post('/neighborhoodList', (req, res) => {
+    console.log("api/neighborhoodList call:")
     console.log(req.body)
     var jsonString = JSON.stringify(OperationsLayer.getNeighborhoodList());
     var jsonParse = JSON.parse(jsonString)
@@ -18,6 +20,7 @@ router.post('/neighborhoodList', (req, res) => {
 })
 
 router.post('/getFilteredData', (req, res) => {
+    console.log("api/getFilteredData call:")
     console.log(req.body)
     let result = JSON.parse(JSON.stringify(analytics.filterByAll(req.body)))
     //console.log(result)
@@ -30,13 +33,29 @@ req: An array with 15 numbers that can be passed into the neighborhood construct
 res: string message saying whether or not create operation was successful.
 */
 router.post('/cards', (req, res) => {
+    console.log("api/cards create:")
     console.log(req.body)
+
+    let neighborhoodData = []
+    for (var key in req.body){
+        if (!isNaN(req.body[key])) {
+            let value = parseInt(req.body[key]);
+            neighborhoodData.push(value);
+        }
+    }
+
+    //console.log(neighborhoodData)
+
     // result var store operation status. 0 means success, -1 means failure
-    var result = OperationsLayer.create(req.body)
-    if (result == 0)
+    var result = OperationsLayer.addNeighborhood(neighborhoodData)
+    if (result == 0) {
+        console.log("create was successful!")
         res.json("Successfully created new neighborhood")
-    else
-        res.json("ERROR: unable to create neighborhood with the given information")
+    }
+    else {
+        console.log("ERROR: unable to create neighborhood with the given information")
+        res.json("ERROR: unable to create neighborhood using the given information")
+    }
 })
 
 /*
@@ -45,13 +64,18 @@ req: The id of the neighborhood to delete within the neighborhoodList.
 res: string message saying whether or not delete operation was successful.
 */
 router.delete('/cards', (req, res) => {
+    console.log("api/cards delete:")
     console.log(req.body)
     // result var store operation status. 0 means success, -1 means failure
     var result = OperationsLayer.deleteNeighborhood(req.body.id)
-    if (result == 0)
-        res.json("Successfully deleted neighborhood with id: " + req.body.id)
-    else
-        res.json("ERROR: unable to delete neighborhood with id of " + req.body.id)
+    if (result == 0) {
+        console.log("delete was successful!")
+        res.json("Successfully deleted neighborhood")
+    }
+    else {
+        console.log("ERROR: unable to delete neighborhood with the given information")
+        res.json("ERROR: unable to delete neighborhood using the given information")
+    }
 })
 
 /*
@@ -61,13 +85,30 @@ req: An array of the 15 values needed to for the neighborhood constructor.
 res: string message saying whether or not delete operation was successful.
 */
 router.patch('/cards', (req, res) => {
-    console.log(req.body)
+    console.log("api/cards update:")
+    console.log(req.body.state)
+
+    let neighborhoodData = []
+    for (var key in req.body.state){
+        // push the neighborhood data only if it's a number
+        if (!isNaN(req.body.state[key])) {
+            let value = parseInt(req.body.state[key]);
+            neighborhoodData.push(value);
+        }
+      }
+
+    //console.log(neighborhoodData)
+
     // result var store operation status. 0 means success, -1 means failure
-    var result = OperationsLayer.update(req.body)
-    if (result == 0)
-        res.json("Successfully updated neighborhood with id: " + req.body.id)
-    else
-        res.json("ERROR: unable to update neighborhood with id: " + req.body.id)
+    var result = OperationsLayer.updateNeighborhood(neighborhoodData)
+    if (result == 0) {
+        console.log("update was successful!")
+        res.json("Successfully updated neighborhood with id: " + req.body.state.id)
+    }
+    else {
+        console.log("ERROR: unable to update neighborhood with the given information")
+        res.json("ERROR: unable to update neighborhood with id: " + req.body.state.id)
+    }
 })
 
 module.exports = router

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -70,11 +70,11 @@ router.delete('/cards', (req, res) => {
     var result = OperationsLayer.deleteNeighborhood(req.body.id)
     if (result == 0) {
         console.log("delete was successful!")
-        res.json("Successfully deleted neighborhood")
+        res.json("Successfully deleted neighborhood with id: " + req.body.id)
     }
     else {
         console.log("ERROR: unable to delete neighborhood with the given information")
-        res.json("ERROR: unable to delete neighborhood using the given information")
+        res.json("ERROR: unable to delete neighborhood with id of " + req.body.id)
     }
 })
 

--- a/server/test/apiTest.js
+++ b/server/test/apiTest.js
@@ -8,7 +8,67 @@ const analytics = require('../analytics');
 chai.use(require('chai-json'))
 chai.use(chaiHttp)
 
-describe("api/cards using router.delete", () => {
+describe("Testing api/test (We keep this around as a single usage example)", () => {
+    it("Should receive {\"first\": \"John\", \"last\": \"Doe\"} after POST to /api/test", () => {
+        const dummyData = {
+            "first": "John",
+            "last": "Doe",
+        }
+
+        chai.request("http://localhost:4000")
+            .post("/api/test")
+            .send({
+                "first": "John",
+                "last": "Doe"
+            }).end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                assert.deepEqual(res.body, dummyData)
+            })
+    })
+})
+
+describe("Testing api/neighborhoodList", () => {
+    it("Should receive the full neighborhoodList array after POST to /api/neighborhoodList", () => {
+        
+        chai.request("http://localhost:4000")
+            .post("/api/neighborhoodList")
+            .send()
+            .end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                expect(res.body.length).to.be.equal(OperationsLayer.getNeighborhoodList().length)
+                //expect(res.body).to.eql(OperationsLayer.getNeighborhoodList()) //assert deep equality
+            })
+    })
+    it("Should receive a filtered neighborhoodList array after POST to /api/getFilteredData", () => {
+
+        let medianHousePrice = [100000, 150000]
+        let latitude = [37, 38]
+        let longitude = [-122, -121]
+        //TODO: Add additional filters to the req once those filters are added to /api/getFilteredData
+        req = JSON.stringify({
+            minMedianHousePrice: medianHousePrice[0],
+            maxMedianHousePrice: medianHousePrice[1],
+            minLatitude: latitude[0],
+            maxLatitude: latitude[1],
+            minLongitude: longitude[0],
+            maxLongitude: longitude[1]
+          })
+
+        chai.request("http://localhost:4000")
+            .post("/api/getFilteredData")
+            .send(req)
+            .end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                expect(res.body.length).to.be.equal(analytics.filterByAll(req).length)
+                expect(res.body).to.eql(analytics.filterByAll(req)) //assert deep equality
+            })
+    })
+})
+
+describe("Testing api/cards using router.delete", () => {
     it("Should return successful delete message after deleting", () => {
         let req = {
             "id": "10"
@@ -40,65 +100,6 @@ describe("api/cards using router.delete", () => {
                 expect(err).to.be.null
                 expect(res).to.be.json
                 expect(res.body).to.be.equal("ERROR: unable to delete neighborhood with id of " + req.id)
-            })
-    })
-
-
-})
-
-describe("Testing API calls", () => {
-    it("Should receive {\"first\": \"John\", \"last\": \"Doe\"} after POST to /api/test", () => {
-        const dummyData = {
-            "first": "John",
-            "last": "Doe",
-        }
-
-        chai.request("http://localhost:4000")
-            .post("/api/test")
-            .send({
-                "first": "John",
-                "last": "Doe"
-            }).end((err, res) => {
-                expect(err).to.be.null
-                expect(res).to.be.json
-                assert.deepEqual(res.body, dummyData)
-            })
-    })
-    it("Should receive the full neighborhoodList array after POST to /api/neighborhoodList", () => {
-        
-        chai.request("http://localhost:4000")
-            .post("/api/neighborhoodList")
-            .send()
-            .end((err, res) => {
-                expect(err).to.be.null
-                expect(res).to.be.json
-                expect(res.body.length).to.be.equal(OperationsLayer.getNeighborhoodList().length)
-                expect(res.body).to.eql(OperationsLayer.getNeighborhoodList()) //assert deep equality
-            })
-    })
-    it("Should receive a filtered neighborhoodList array after POST to /api/getFilteredData", () => {
-
-        let medianHousePrice = [100000, 150000]
-        let latitude = [37, 38]
-        let longitude = [-122, -121]
-        //TODO: Add additional filters to the req once those filters are added to /api/getFilteredData
-        req = JSON.stringify({
-            minMedianHousePrice: medianHousePrice[0],
-            maxMedianHousePrice: medianHousePrice[1],
-            minLatitude: latitude[0],
-            maxLatitude: latitude[1],
-            minLongitude: longitude[0],
-            maxLongitude: longitude[1]
-          })
-
-        chai.request("http://localhost:4000")
-            .post("/api/getFilteredData")
-            .send(req)
-            .end((err, res) => {
-                expect(err).to.be.null
-                expect(res).to.be.json
-                expect(res.body.length).to.be.equal(analytics.filterByAll(req).length)
-                expect(res.body).to.eql(analytics.filterByAll(req)) //assert deep equality
             })
     })
 })


### PR DESCRIPTION
Successfully passed the information for the CREATE, DELETE, and UPDATE api calls from the client to the server to perform the respective functions. I had to add a new AddCard state for _total_rooms, as it was missing in the states. Currently, the UI doesn't display the _total_rooms for a neighborhood, so we probably want to add that to the card in the near future.

The Create api call requires all the data needed to construct a new neighborhood *except for* than the id. The correct id is automatically  generated by the OperationsLayer.addNeighorhood() function.

The Update API call requires  all the data needed to construct a new neighborhood, *including* the id of the neighborhood to be updated. we can just obtain the id straight from the req.body.state, so we actually don't need to pass the id as a separate JSON item.

Overall, the operations work on the UI. However, the UI doesn't get the updated data after CREATE, DELETE, and UPDATE api calls are made. Currently, the changes can only be viewed if you press that get all data or get filtered data buttons after making a change.

The unit test for the delete function needs to be changed to re-add the data that it just deleted. That way, the unit test won't fail after successive calls to npm test as a result of the unit test making changes to the database.

We still need to make unit tests for the api/cards CREATE and UPDATE functions. However, it can be confirmed on the client that they are working as intended.

This PR is a tad messy and needs a small amount of refactoring, but it's functional and that's what matters most.