### PR TITLE
Improved test cases for data manipulation functions

### DIFF
--- a/server/operations.js
+++ b/server/operations.js
@@ -73,7 +73,7 @@ class OperationsLayer {
 	Add a new neighborhood with the specified data
 	*/
 	static addNeighborhood(neighborhoodData) {
-		if(!isLoaded) initializeDataLayer();
+		if(!isLoaded) OperationsLayer.initializeDataLayer();
 
 		if(neighborhoodData.length == 14 && !isNaN(Number(neighborhoodData[1]))) {
 			neighborhoodData.push(neighborhoodList.at(-1).id + 1) 		// Create a new neighborhood ID by incrementing

--- a/server/test/operationsTest.js
+++ b/server/test/operationsTest.js
@@ -17,48 +17,61 @@ describe("operations.getNeighborhoodList function", () => {
 });
 
 describe("operations.deleteNeighborhood function", () => {
+    let neighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106];
+    OperationsLayer.addNeighborhood(neighborhoodData); // Add a neighborhood to neighborhoodList to delete later
+    let lastID = OperationsLayer.getNeighborhoodList().at(-1).id;
+    let lengthBeforeDelete = OperationsLayer.getNeighborhoodList().length; // Length of the neighborhoodList before a row is deleted
+    let deleteCode = OperationsLayer.deleteNeighborhood(lastID); // Delete the last neighborhood and return 0 if successful
+    let lengthAfterDelete = OperationsLayer.getNeighborhoodList().length;  // Length of the neighborhoodList after a row is deleted
+
     it("LengthAfterDelete should be 1 less than LengthBeforeDelete", () => {
-
-        lengthBeforeDelete = OperationsLayer.getNeighborhoodList().length; // Length of the neighborhoodList before a row is deleted
-        deleteCode = OperationsLayer.deleteNeighborhood(10); // Delete id 10 and return 0 if successful
-        lengthAfterDelete = OperationsLayer.getNeighborhoodList().length;  // Length of the neighborhoodList after a row is deleted
-
         expect(deleteCode).to.be.equal(0);
         expect(lengthAfterDelete).to.be.equal(lengthBeforeDelete - 1);
     })
     it("Should fail to delete neighborhood with id -1 and return -1", () => {
         expect(OperationsLayer.deleteNeighborhood(-1)).to.be.equal(-1);
     })
-    it("Should fail to delete neighborhood with id 10 and return -1", () => {
-        expect(OperationsLayer.deleteNeighborhood(10)).to.be.equal(-1);
+    it("Should fail to delete neighborhood with an id of lastID -1", () => {
+        expect(OperationsLayer.deleteNeighborhood(lastID)).to.be.equal(-1);
     })
 });
 
 describe("operations.addNeighborhood function", () => {
-	    
-    it("Should add a new neighborhood with the specified data to neighborhoodList", () => {
-        neighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106];
-        lastID = OperationsLayer.getNeighborhoodList().at(-1).id;
-        lengthBeforeAdd = OperationsLayer.getNeighborhoodList().length;
+	neighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106];
+    lastID = OperationsLayer.getNeighborhoodList().at(-1).id;
+    lengthBeforeAdd = OperationsLayer.getNeighborhoodList().length;
+    addFunctionStatus = OperationsLayer.addNeighborhood(neighborhoodData) // Adds a new neighborhood and returns 0 if successful
+    lengthAfterAdd = OperationsLayer.getNeighborhoodList().length;
+    addedMedian = OperationsLayer.getNeighborhoodList().at(-1).median_value;
+    addedID = OperationsLayer.getNeighborhoodList().at(-1).id
 
-        expect(OperationsLayer.addNeighborhood(neighborhoodData)).to.be.equal(0);
-        lengthAfterAdd = OperationsLayer.getNeighborhoodList().length;
-        expect(lengthBeforeAdd).to.be.equal(lengthAfterAdd - 1);
-        expect(OperationsLayer.getNeighborhoodList().at(-1).median_value).to.be.equal(360000);
-        expect(OperationsLayer.getNeighborhoodList().at(-1).id).to.be.equal(lastID + 1);
+    OperationsLayer.deleteNeighborhood(lastID + 1); // Undo the neighborhood that we added
+
+    it("Should add a new neighborhood to neighborhoodList", () => {
+        expect(addFunctionStatus).to.be.equal(0);
     })
+    it("Should read in the correct number of rows for neighborhoodList", () => {
+        expect(lengthAfterAdd).to.be.equal(lengthBeforeAdd + 1);
+    })
+    it("Should read the correct values for the added neighborhood", () => {
+        expect(addedMedian).to.be.equal(360000);
+        expect(addedID).to.be.equal(lastID + 1);
+    })
+
 });
 
 describe("operations.updateNeighborhood function", () => {
-	    
+	validNeighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106, 9];
+    invalidNeighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106, -1];
+
     it("Should update the neighborhood with the specified data and id in neighborhoodList", () => {
-        neighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106, 9];
-        expect(OperationsLayer.updateNeighborhood(neighborhoodData)).to.be.equal(0);
+        expect(OperationsLayer.updateNeighborhood(validNeighborhoodData)).to.be.equal(0);
+    })
+    it("Should read the correct values for the updated neighborhood", () => {
         expect(OperationsLayer.getNeighborhoodList().at(8).median_value).to.be.equal(360000);
         expect(OperationsLayer.getNeighborhoodList().at(8).id).to.be.equal(9);
     })
     it("Should fail if we attempt to update a neighborhood with an invalid id", () => {
-        neighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106, -1];
-        expect(OperationsLayer.updateNeighborhood(neighborhoodData)).to.be.equal(-1);
+        expect(OperationsLayer.updateNeighborhood(invalidNeighborhoodData)).to.be.equal(-1);
     })
 });


### PR DESCRIPTION
<h1>Updated Operation.js test cases</h1>

I updated the test cases for the deleteNeighborhood and addNeighborhood function so that the neighborhoodList is the same at the start of the test as it is at the end of the test, and made the test cases more specific

We are still having a problem where api test cases fail if you run the test suite more than once

There's not much here you have to scrutinize, all I did was improve test cases.