### PR TITLE
CSS Minor Facelift + Factoids Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 */node_modules/
+server/California_Houses_Backup.csv

--- a/client/src/components/Card.css
+++ b/client/src/components/Card.css
@@ -3,7 +3,7 @@
     padding: 0.5em;
     padding-bottom: 2em;
     border-radius: 10px;
-    background-color: lightblue;
+    background-color: #B5E2FA;
     margin: 0.7em 0;
     display: flex;
     flex-direction: column;
@@ -11,8 +11,8 @@
 }
 
 .card:hover {
-    background-color: lightgray;
-    box-shadow: 0 0.2em 10px 0.2em grey;
+    background-color: #79cefc;
+    box-shadow: 0 0.2em 10px 0.2em rgb(187, 186, 186);
 }
 
 .card > #keyInfo {

--- a/client/src/components/Card.js
+++ b/client/src/components/Card.js
@@ -39,7 +39,7 @@ class Card extends Component {
                     <div id='homeValue'>${this.props._median_value}</div> @
                     <div id='location'>({this.props._latitude}, {this.props._longitude}), closest to</div>
                     <div id='metro'>{this.props._closest_metro}</div>
-                    <img id='dropdown-arrow' className={this.state.isEditMode ? `down` : `up`}  src="/dropdown_arrow.png" alt="dropdown arrow" onClick={this.toggleState}/>
+                    <img id='dropdown-arrow' className={this.state.isEditMode ? `down` : `up` + (this.props.editingEnabled? ``: ` hidden`)}  src="/dropdown_arrow.png" alt="dropdown arrow" onClick={this.toggleState}/>
                 </div>
                 <div id='aboutTheNeighborhood' className="column-flex">
                     <div>Population: {this.props._population}</div> |

--- a/client/src/components/Card.js
+++ b/client/src/components/Card.js
@@ -6,7 +6,7 @@ Note: Unlike the other components throughout the app, this one is class based.
 
 import './Card.css'
 import { Component } from 'react'
-import EditAttributes from './EditAttributes'
+import EditCard from './EditCard'
 
 class Card extends Component {
     constructor(props) {
@@ -24,6 +24,7 @@ class Card extends Component {
 
     changeValue(attributeName, value) {
         try {
+            console.log(`Setting ${attributeName} to ${value}`)
             this.setState({
                 [attributeName]: value
             })
@@ -48,14 +49,7 @@ class Card extends Component {
                     <div>Median income: ${(this.props._median_income * 10000).toPrecision(5)}</div> |
                     <div>Median age: {this.props._median_age}</div>
                 </div>
-            <div id="editCard" className={this.state.isEditMode ? `blank` : `hidden`}>{/*TODO: Fill this in, and display: NONE while doing so.*/}
-                <div id='header'>Edit Information</div>
-                <EditAttributes {...this.state} onChange={(e) => this.changeValue(e.target.id, e.target.value)}/>
-                <div id='options-div'>
-                        <button onClick={() => this.props.updateData(this.props._id, this.state)}>Update data</button>
-                        <button onClick={() => this.props.deleteEntry(this.props._id)}>Delete entry</button>
-                </div>
-            </div>
+                <EditCard {...this.state} changeValue={this.changeValue} updateData={() => this.props.updateData(this.props._id, this.state)} deleteEntry={() => this.props.deleteEntry(this.props._id)}/>
         </div>
     }
 }

--- a/client/src/components/Dropdown.css
+++ b/client/src/components/Dropdown.css
@@ -17,7 +17,7 @@
 }
 
 .chosenItem {
-    background-color: aqua;
+    background-color: #B5E2FA;
 }
 
 /* Copied from Card.css. Consider merging into index.css. */

--- a/client/src/components/EditCard.js
+++ b/client/src/components/EditCard.js
@@ -1,0 +1,20 @@
+import { Component } from "react"
+import EditAttributes from "./EditAttributes"
+
+class EditCard extends Component {
+    render() {
+        return (<div>
+            <div id="editCard" className={this.props.isEditMode ? `blank` : `hidden`}>{/*TODO: Fill this in, and display: NONE while doing so.*/}
+            <div id='header'>Edit Information</div>
+            <EditAttributes {...this.props} onChange={(e) => this.props.changeValue(e.target.id, e.target.value)}/>
+            <div id='options-div'>
+                <button onClick={this.props.updateData}>Update data</button>
+                <button onClick={this.props.deleteEntry}>Delete entry</button>
+            </div>
+            </div>
+        </div>
+        )
+    }
+}
+
+export default EditCard

--- a/client/src/components/navbar.css
+++ b/client/src/components/navbar.css
@@ -3,7 +3,7 @@
 }
 
 .bg-light {
-    background-color: lightgrey;
+    background-color: #0FA3B1;
 }
 
 .full-width {
@@ -15,15 +15,22 @@ ul {
 }
 
 li {
+    margin-top: auto;
     margin-left: 1rem;
     list-style-type: none;
 }
 
 a {
-    color: rgb(119, 119, 119);
+    color: #EDDEA4;
     text-decoration: none;
 }
 
 a:hover {
-    color: darkgrey;
+    color: #ffdb4d;
+}
+
+.logo-title {
+    color: #F7A072;
+    font-weight: bold;
+    font-size: x-large;
 }

--- a/client/src/components/navbar.js
+++ b/client/src/components/navbar.js
@@ -6,6 +6,7 @@ const Navbar = () => {
       <nav className="navbar navbar-expand-lg navbar-light bg-light">
       <div className="collapse navbar-collapse full-width" id="navbarNavDropdown">
         <ul className="navbar-nav flex-horizontal">
+        <div className="logo-title">1990 Housing Data Viewer</div>
           <li className="nav-item">
             <a className="nav-link" href="/">
               View Data

--- a/client/src/components/navbar.js
+++ b/client/src/components/navbar.js
@@ -16,6 +16,11 @@ const Navbar = () => {
               Analytics
             </a>
           </li>
+          <li className="nav-item">
+            <a className="nav-link" href="factoids">
+              Factoids
+            </a>
+          </li>
         </ul>
       </div>
     </nav>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,6 +5,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #F9F7F3;
 }
 
 code {
@@ -41,3 +42,36 @@ code {
 h1 {
   text-align: center;
 }
+
+.small-margin-top {
+  margin-top: 1rem;
+}
+
+input[type=number] {
+  border: none;
+  border-radius: 10px;
+}
+
+button, input[type=submit] {
+  background-color: #EDDEA4;
+  border: none;
+  border-radius: 10px;
+  margin: 0.3rem;
+}
+
+button:hover, input[type=submit]:hover {
+  background-color: #eeda89;
+}
+
+/*
+Randomly-generated color pallette that might look alright
+
+Header -> #0FA3B1 ("Viridian Green")
+Cards -> #B5E2FA ("Uranian Blue")
+Background/Small details -> #F9F7F3 ("Baby Powder")
+
+Unused:
+#EDDEA4 ("Medium Champagne")
+#F7A072 ("Atomic Tangerine") -> Maybe emphasized text?
+
+*/

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,6 +5,7 @@ import reportWebVitals from './reportWebVitals';
 import {Routes, Route, BrowserRouter} from 'react-router-dom'
 import Graph from './routes/Graphs';
 import "./index.css"
+import Factoids from './routes/Factoids';
 
 
 const root = createRoot(document.getElementById('root'))
@@ -14,6 +15,7 @@ const main = (
       <Routes>
         <Route path = "/" element={<Data/>}/> 
         <Route path = "/graph" element={<Graph/>}/>
+        <Route path = "/factoids" element={<Factoids/>}/>
         {/* TODO: Replace the above path with /data, and create a separate connected homepage. */}
       </Routes>
     </BrowserRouter>

--- a/client/src/routes/Data.js
+++ b/client/src/routes/Data.js
@@ -138,7 +138,6 @@ function Data() {
       </div>
       <div className="page-contents">
       <h1>1990 Housing Data Viewer</h1>
-      <h3>A reminder that today's economy is screwed for the rest of us</h3>
         {/* Two Sided Sliders for all of the data values*/}
         <div id='slider-container'>
           <div className="slider">

--- a/client/src/routes/Data.js
+++ b/client/src/routes/Data.js
@@ -209,7 +209,7 @@ function Data() {
       <div id='card-container'>
         <AddCard cardContainerSetter={setCardContainer}/>
         {tempCardContainer.map(element => {
-          return <Card {...element} updateData={updateData} deleteEntry={deleteEntry}/>
+          return <Card {...element} editingEnabled={true} updateData={updateData} deleteEntry={deleteEntry}/>
         })}
       </div>
     </div>

--- a/client/src/routes/Data.js
+++ b/client/src/routes/Data.js
@@ -76,7 +76,7 @@ function Data() {
     if(cardContainer.length >= 0) {
       setTempCardContainer(cardContainer.slice(0, maxShow))
     }
-  }, [cardContainer, tempCardContainer, maxShow])
+  }, [cardContainer, maxShow])
 
   
   useEffect(() => {
@@ -98,7 +98,11 @@ function Data() {
    * @param {Object} entryState - The JSONified state of the element. You do not need to remove the 'isEditMode' property.
    */
   async function updateData(entryId, entryState) {
+    // const state = Object.assign(entryState)
+    // console.log(state)
+    console.log(entryState)
     delete entryState['isEditMode'] //Safe delete, remove unused state
+    console.log(entryState)
     console.log("Entry", entryId, "updated with", entryState)
     await fetch('http://localhost:4000/api/cards', {
       method: 'PATCH',
@@ -219,8 +223,6 @@ function Data() {
 async function fetchAllData() {
   displayAllData(await postFunc('api/neighborhoodList', "api/neighborhoodList called"))
 }
-
-
 
 async function fetchFilteredData(medianHousePrice, medianIncome, medianAge, totalRooms, totalBedrooms, population, households, latitude, longitude, distanceToCoast, distanceToLA, distanceToSD, distanceToSJ, distanceToSF, id) {
   fetch('http://localhost:4000/api/getFilteredData', {

--- a/client/src/routes/Data.js
+++ b/client/src/routes/Data.js
@@ -43,8 +43,7 @@ export const defaultHeaders = {
 
 let setCardContainerOuter
 
-fetchAllData() //Display data on initial run
-
+fetchAllData() //Display data on initial run, when the items are rendered.
 
 function Data() {
   // Functions to get the slider states
@@ -141,7 +140,6 @@ function Data() {
         <Navbar />
       </div>
       <div className="page-contents">
-      <h1>1990 Housing Data Viewer</h1>
         {/* Two Sided Sliders for all of the data values*/}
         <div id='slider-container'>
           <div className="slider">

--- a/client/src/routes/Factoids.css
+++ b/client/src/routes/Factoids.css
@@ -8,7 +8,3 @@
     margin-left: auto;
     margin-right: auto;
 }
-
-.card > #keyInfo > img {
-    display: none;
-}

--- a/client/src/routes/Factoids.css
+++ b/client/src/routes/Factoids.css
@@ -1,0 +1,14 @@
+.column-grow {
+    text-align: center;
+    width: 25%;
+}
+
+.card {
+    width: 70%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.card > #keyInfo > img {
+    display: none;
+}

--- a/client/src/routes/Factoids.js
+++ b/client/src/routes/Factoids.js
@@ -53,7 +53,7 @@ render() {
                 <h3>By Highest Median House Price</h3>
                 {
                     this.state.cardContainer.slice(0, 10).map(element => {
-                        return <Card {...element} updateData={function () { }} deleteEntry={function () { }} />
+                        return <Card {...element} editingEnabled={false} />
                     })
                 }
             </div>
@@ -61,7 +61,7 @@ render() {
                 <h3>By Lowest Median House Price</h3>
                 {
                     this.state.cardContainer.slice(0, 10).map(element => {
-                        return <Card {...element} updateData={function () { }} deleteEntry={function () { }} />
+                        return <Card {...element} editingEnabled={false} />
                     })
                 }
             </div>
@@ -69,7 +69,7 @@ render() {
                 <h3>By Closest Distance to Coast</h3>
                 {
                     this.state.cardContainer.slice(0, 10).map(element => {
-                        return <Card {...element} updateData={function () { }} deleteEntry={function () { }} />
+                        return <Card {...element} editingEnabled={false} />
                     })
                 }
             </div>
@@ -77,7 +77,7 @@ render() {
                 <h3>By Highest Population</h3>
                 {
                     this.state.cardContainer.slice(0, 10).map(element => {
-                        return <Card {...element} updateData={function () { }} deleteEntry={function () { }} />
+                        return <Card {...element} editingEnabled={false} />
                     })
                 }
             </div>

--- a/client/src/routes/Factoids.js
+++ b/client/src/routes/Factoids.js
@@ -1,0 +1,14 @@
+/*
+Factoids page! Should contain some interesting answers to some questions we want answered.
+*/
+
+import Navbar from "../components/navbar";
+
+export default function Factoids() {
+    return(
+    <div>
+        <Navbar/>
+        <h1>1990 Housing Data Viewer - Factoids</h1>
+    </div>
+    )
+}

--- a/client/src/routes/Factoids.js
+++ b/client/src/routes/Factoids.js
@@ -3,12 +3,86 @@ Factoids page! Should contain some interesting answers to some questions we want
 */
 
 import Navbar from "../components/navbar";
+import "./Factoids.css"
+import defaultHeaders from "../routes/Data.js"
+import Card from "../components/Card.js"
+import { Component } from "react";
 
-export default function Factoids() {
-    return(
-    <div>
-        <Navbar/>
+export default class Factoids extends Component {
+    //TODO: Remove mock data getter
+    async postFuncMock() {
+        try {
+            let response = await fetch('http://localhost:4000/api/neighborhoodList', {
+                method: 'POST',
+                headers: defaultHeaders,
+                body: JSON.stringify({
+                    firstParam: "MOCK TEST PLEASE REMOVE BEFORE PROD"
+                })
+            })
+    
+            //turn the POST response into a json file, and return the firstParam
+    
+            let data = await response.json()
+            for (var i = 0; i < data.length; i++) {
+                data[i].key = data[i]._id
+                // container.push(data[i])
+            }
+            return data
+        }
+        catch (error) {
+            console.error("ERROR: No response from server. Please check if server is running.");
+            return "ERROR: No Response From Server";
+        }
+    }
+
+    constructor(props) {
+        super(props)
+        this.state = Object.assign({ ...props }, {cardContainer: []})
+        this.postFuncMock().then(data => {
+            this.state.cardContainer = data
+            this.forceUpdate()
+        })
+    }
+
+render() {
+    return (<div>
+        <Navbar />
         <h1>1990 Housing Data Viewer - Factoids</h1>
-    </div>
-    )
+        <h2>Top 10 Neighborhoods...</h2>
+        <div id="3-questions-answered" className="flex-horizontal">
+            <div className="column-grow align-center">
+                <h3>By Highest Median House Price</h3>
+                {
+                    this.state.cardContainer.slice(0, 10).map(element => {
+                        return <Card {...element} updateData={function () { }} deleteEntry={function () { }} />
+                    })
+                }
+            </div>
+            <div className="column-grow">
+                <h3>By Lowest Median House Price</h3>
+                {
+                    this.state.cardContainer.slice(0, 10).map(element => {
+                        return <Card {...element} updateData={function () { }} deleteEntry={function () { }} />
+                    })
+                }
+            </div>
+            <div className="column-grow">
+                <h3>By Closest Distance to Coast</h3>
+                {
+                    this.state.cardContainer.slice(0, 10).map(element => {
+                        return <Card {...element} updateData={function () { }} deleteEntry={function () { }} />
+                    })
+                }
+            </div>
+            <div className="column-grow">
+                <h3>By Highest Population</h3>
+                {
+                    this.state.cardContainer.slice(0, 10).map(element => {
+                        return <Card {...element} updateData={function () { }} deleteEntry={function () { }} />
+                    })
+                }
+            </div>
+        </div>
+    </div>)
+}
 }

--- a/client/src/routes/Factoids.js
+++ b/client/src/routes/Factoids.js
@@ -9,39 +9,59 @@ import Card from "../components/Card.js"
 import { Component } from "react";
 
 export default class Factoids extends Component {
-    //TODO: Remove mock data getter
-    async postFuncMock() {
-        try {
-            let response = await fetch('http://localhost:4000/api/neighborhoodList', {
-                method: 'POST',
-                headers: defaultHeaders,
-                body: JSON.stringify({
-                    firstParam: "MOCK TEST PLEASE REMOVE BEFORE PROD"
-                })
+    /**
+     * getColumns
+     * 
+     * Calls the getColumnByName for each respective method.
+     */
+    async getColumns() {
+        this.getColumnByName('highestMedianValue').then(data => {
+            this.setState({
+                highestMedianValue: data
             })
-    
-            //turn the POST response into a json file, and return the firstParam
-    
-            let data = await response.json()
-            for (var i = 0; i < data.length; i++) {
-                data[i].key = data[i]._id
-                // container.push(data[i])
-            }
-            return data
-        }
-        catch (error) {
-            console.error("ERROR: No response from server. Please check if server is running.");
-            return "ERROR: No Response From Server";
+        })
+        this.getColumnByName('lowestMedianValue').then(data => {
+            this.setState({
+                lowestMedianValue: data
+            })
+        })
+        this.getColumnByName('closestDistanceToCoast').then(data => {
+            this.setState({
+                closestDistanceToCoast: data
+            })
+        })
+        this.getColumnByName('highestPopulation').then(data => {
+            this.setState({
+                highestPopulation: data
+            })
+        })
+    }
+
+    async getColumnByName(name) {
+        try {
+            const response = await fetch('http://localhost:4000/api/cache?' + new URLSearchParams({column: name}).toString(), {
+                method: 'GET',
+                headers: defaultHeaders
+            }).then(data => data.json())
+            return response
+        } catch(error) {
+            console.error(error)
+            return null
         }
     }
 
     constructor(props) {
         super(props)
-        this.state = Object.assign({ ...props }, {cardContainer: []})
-        this.postFuncMock().then(data => {
-            this.state.cardContainer = data
-            this.forceUpdate()
-        })
+        this.state = {
+            highestMedianValue: [],
+            lowestMedianValue: [],
+            closestDistanceToCoast: [],
+            highestPopulation: []
+        }
+    }
+
+    async componentDidMount() {
+        await this.getColumns()
     }
 
 render() {
@@ -52,7 +72,7 @@ render() {
             <div className="column-grow align-center">
                 <h3>By Highest Median House Price</h3>
                 {
-                    this.state.cardContainer.slice(0, 10).map(element => {
+                    this.state.highestMedianValue.map(element => {
                         return <Card {...element} editingEnabled={false} />
                     })
                 }
@@ -60,7 +80,7 @@ render() {
             <div className="column-grow">
                 <h3>By Lowest Median House Price</h3>
                 {
-                    this.state.cardContainer.slice(0, 10).map(element => {
+                    this.state.lowestMedianValue.map(element => {
                         return <Card {...element} editingEnabled={false} />
                     })
                 }
@@ -68,7 +88,7 @@ render() {
             <div className="column-grow">
                 <h3>By Closest Distance to Coast</h3>
                 {
-                    this.state.cardContainer.slice(0, 10).map(element => {
+                    this.state.closestDistanceToCoast.map(element => {
                         return <Card {...element} editingEnabled={false} />
                     })
                 }
@@ -76,7 +96,7 @@ render() {
             <div className="column-grow">
                 <h3>By Highest Population</h3>
                 {
-                    this.state.cardContainer.slice(0, 10).map(element => {
+                    this.state.highestPopulation.map(element => {
                         return <Card {...element} editingEnabled={false} />
                     })
                 }

--- a/client/src/routes/Factoids.js
+++ b/client/src/routes/Factoids.js
@@ -47,7 +47,6 @@ export default class Factoids extends Component {
 render() {
     return (<div>
         <Navbar />
-        <h1>1990 Housing Data Viewer - Factoids</h1>
         <h2>Top 10 Neighborhoods...</h2>
         <div id="3-questions-answered" className="flex-horizontal">
             <div className="column-grow align-center">

--- a/client/src/routes/Graphs.js
+++ b/client/src/routes/Graphs.js
@@ -149,8 +149,7 @@ class Graph extends Component{
             <div id='navigation-bar'>
                 <Navbar />
             </div>
-            <h1>1990 Housing Data Viewer - Graphs</h1>
-            <div className="flex-horizontal">
+            <div className="flex-horizontal small-margin-top">
             <div className="big-font small-horizontal-padding">Choose a column to compare against median housing:</div>
             <Dropdown items={items} changed={this.changeSelectedData} selected={this.state.selectedColumn}/>
             </div>

--- a/server/analytics.js
+++ b/server/analytics.js
@@ -4,6 +4,27 @@ const Neighborhood = require('./neighborhood')
 function filterByAll(constraintArray) {
 	return OperationsLayer.filterByAll(constraintArray);
 }
+
+function getHighestMedianValue() {
+	var highestValueCache = OperationsLayer.getHighestValueCache();
+	return highestValueCache.slice(0,10)
+}
+
+function getLowestMedianValue() {
+	var lowestValueCache = OperationsLayer.getLowestValueCache();
+	return lowestValueCache.slice(0,10)
+}
+
+function getClosestDistanceToCoast() {
+	var closestCoastCache = OperationsLayer.getClosestCoastCache();
+	return closestCoastCache.slice(0,10)
+}
+
+function getHighestPopulation() {
+	var highestPopulationCache = OperationsLayer.getHighestPopulationCache();
+	return highestPopulationCache.slice(0,10)
+}
+
 function getColumn(constraintArray,x){
 	let list=OperationsLayer.filterByAll(constraintArray);
 	let column=[]
@@ -58,4 +79,8 @@ function getColumn(constraintArray,x){
 }
 
 exports.filterByAll = filterByAll
+exports.getHighestMedianValue = getHighestMedianValue
+exports.getLowestMedianValue = getLowestMedianValue
+exports.getClosestDistanceToCoast = getClosestDistanceToCoast
+exports.getHighestPopulation = getHighestPopulation
 exports.getColumn = getColumn

--- a/server/operations.js
+++ b/server/operations.js
@@ -9,10 +9,10 @@ const Neighborhood = require('./neighborhood') // Required to call Neighborhood 
 
 let isLoaded = false
 let neighborhoodList = []
-let highMedian = []
-let lowMedian = []
-let closestCoast = []
-let highestPop = []
+let highestValueCache = []
+let lowestValueCache = []
+let closestCoastCache = []
+let highestPopulationCache = []
 
 class OperationsLayer {
 	//Singleton constructor. If data already loaded, then return the list. Otherwise, load the list.
@@ -30,21 +30,23 @@ class OperationsLayer {
 		if(!isLoaded) OperationsLayer.initializeDataLayer();
 		return neighborhoodList
 	}
-	static getHighestPop() {
+
+	// Functions to return min and max value from the cache
+	static getHighestPopulationCache() {
 		if(!isLoaded) OperationsLayer.initializeDataLayer();
-		return highestPop
+		return highestPopulationCache
 	}	
-	static getHighMedianCache() {
+	static getHighestValueCache() {
 		if(!isLoaded) OperationsLayer.initializeDataLayer();
-		return highMedian
+		return highestValueCache
 	}	
-	static getLowMedianCache() {
+	static getLowestValueCache() {
 		if(!isLoaded) OperationsLayer.initializeDataLayer();
-		return lowMedian
+		return lowestValueCache
 	}	
-	static getClosestCoast() {
+	static getClosestCoastCache() {
 		if(!isLoaded) OperationsLayer.initializeDataLayer();
-		return closestCoast
+		return closestCoastCache
 	}
 	/*
 	Function to get the entire NeighborhoodList array from the csv.
@@ -67,33 +69,33 @@ class OperationsLayer {
 	}
 
 	static createHighCache(){
-		highMedian.splice(0,highMedian.length)
+		highestValueCache.splice(0,highestValueCache.length)
 		for(let i=0; i<20; i++){
-			highMedian.push(neighborhoodList[neighborhoodList.length-1-i]);
+			highestValueCache.push(neighborhoodList[neighborhoodList.length-1-i]);
 		}
 	}
 
 	static createLowCache(){
-		lowMedian.splice(0,lowMedian.length)
+		lowestValueCache.splice(0,lowestValueCache.length)
 		for(let i=0; i<20; i++){
-			lowMedian.push(neighborhoodList[i])
+			lowestValueCache.push(neighborhoodList[i])
 		}
 	}
 
 	static createCloseCache(){
-		closestCoast.splice(0,closestCoast.length);
+		closestCoastCache.splice(0,closestCoastCache.length);
 		neighborhoodList.sort(function(a,b){return a.distance_to_coast - b.distance_to_coast});
 		for(let i=0; i<20; i++){
-			closestCoast.push(neighborhoodList[i]);
+			closestCoastCache.push(neighborhoodList[i]);
 		}
 		neighborhoodList.sort(function(a,b){return a.id - b.id});
 	}
 
 	static createPopCache(){
-		highestPop.splice(0,highestPop.length);
+		highestPopulationCache.splice(0,highestPopulationCache.length);
 		neighborhoodList.sort(function(a,b){return b.population - a.population});
 		for(let i=0; i<20; i++){
-			highestPop.push(neighborhoodList[i]);
+			highestPopulationCache.push(neighborhoodList[i]);
 		}
 		neighborhoodList.sort(function(a,b){return a.id - b.id});
 	}
@@ -147,8 +149,9 @@ class OperationsLayer {
 		for(let i = 0; i < neighborhoodList.length; i++) {
 			if(neighborhoodList[i].id == id){
 				//delete the neighborhood at index location i
-				neighborhoodList.splice(i, 1);	
 				csv.save(neighborhoodList, "California_Houses_Backup.csv");
+				this.updateCacheDelete(neighborhoodList[i]);
+				neighborhoodList.splice(i, 1);
 				return 0; // addNeighborhood successful.
 			}	
 		}
@@ -165,6 +168,7 @@ class OperationsLayer {
 			neighborhoodData.push(Number(neighborhoodList.at(-1).id) + 1) 		// Create a new neighborhood ID by incrementing
             const newNeighborhood = new Neighborhood(neighborhoodData); // Create a new neighborhood with neighborhoodData 
 			neighborhoodList.push(newNeighborhood);						// Add the new neighborhood to neighborhoodList
+			this.updateCacheAdd(newNeighborhood); // Update the cache
 			csv.save(neighborhoodList, "California_Houses_Backup.csv");
 			return 0; // addNeighborhood successful.
         }	
@@ -184,12 +188,13 @@ class OperationsLayer {
 	Modify the neighborhood with the specified id
 	*/
 	static updateNeighborhood(neighborhoodData) {
-		if(!isLoaded) initializeDataLayer();
+		if(!isLoaded) OperationsLayer.initializeDataLayer();
 		if(neighborhoodData.length == 15 && !isNaN(Number(neighborhoodData[1]))) {
             const newNeighborhood = new Neighborhood(neighborhoodData); // Create a new neighborhood with neighborhoodData 
 			for(let i = 0; i < neighborhoodList.length; i++) {
 				if(neighborhoodList[i].id == neighborhoodData[14]){ // Find the neighborhood with the specified id
 					//Replace the neighborhood at index location i with the newNeighborhood
+					this.updateCacheUpdate(newNeighborhood);
 					neighborhoodList[i] = newNeighborhood;
 					csv.save(neighborhoodList, "California_Houses_Backup.csv");
 					return 0; // addNeighborhood successful.
@@ -197,6 +202,82 @@ class OperationsLayer {
 			}
         }
 		return -1; // addNeighborhood failed.
+	}
+
+	// Check to see if the cache needs to be updated, and do so
+	static updateCacheDelete(neighborhood) {
+		for(let i = 0; i < highestValueCache.length; i++) {
+			if(neighborhood.id == highestValueCache[i].id) {
+				highestValueCache.splice(i, 1); // Delete value from cache
+
+				if(highestValueCache.length < 10)
+					this.createMedianCaches();
+
+				break;
+			}
+		}
+		for(let i = 0; i < lowestValueCache.length; i++) {
+			if(neighborhood.id == lowestValueCache[i].id) {
+				lowestValueCache.splice(i, 1); // Delete value from cache
+
+				if(lowestValueCache.length < 10)
+					this.createMedianCaches();
+
+				break;
+			}
+		}
+		for(let i = 0; i < closestCoastCache.length; i++) {
+			if(neighborhood.id == closestCoastCache[i].id) {
+				closestCoastCache.splice(i, 1); // Delete value from cache
+
+				if(closestCoastCache.length < 10)
+					this.createCloseCache();
+
+				break;
+			}
+		}
+		for(let i = 0; i < highestPopulationCache.length; i++) {
+			if(neighborhood.id == highestPopulationCache[i].id) {
+				highestPopulationCache.splice(i, 1); // Delete value from cache
+
+				if(highestPopulationCache.length < 10)
+					this.createPopCache();
+
+				break;
+			}
+		}
+	}
+
+	static updateCacheAdd(neighborhood) {
+		for(let i = 0; i < highestValueCache.length; i++) {
+			if(neighborhood.median_value > highestValueCache[i].median_value) {
+				highestValueCache.splice(i, 0, neighborhood); // Add a new value to the cache
+				break;
+			}
+		}
+		for(let i = 0; i < lowestValueCache.length; i++) {
+			if(neighborhood.median_value < lowestValueCache[i].median_value) {
+				lowestValueCache.splice(i, 0, neighborhood); // Add a new value to the cache
+				break;
+			}
+		}
+		for(let i = 0; i < closestCoastCache.length; i++) {
+			if(neighborhood.distance_to_coast < closestCoastCache[i].distance_to_coast) {
+				closestCoastCache.splice(i, 0, neighborhood); // Add a new value to the cache
+				break;
+			}
+		}
+		for(let i = 0; i < highestPopulationCache.length; i++) {
+			if(neighborhood.population > highestPopulationCache[i].population) {
+				highestPopulationCache.splice(i, 0, neighborhood); // Add a new value to the cache
+				break;
+			}
+		}
+	}
+
+	static updateCacheUpdate(neighborhood) {
+		this.updateCacheDelete(neighborhood);
+		this.updateCacheAdd(neighborhood);
 	}
 	
 }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -13,17 +13,14 @@ router.post('/test', (req, res) => {
 
 router.post('/neighborhoodList', (req, res) => {
     console.log("api/neighborhoodList call:")
-    //console.log(req.body)
 
-    var jsonString = JSON.stringify(OperationsLayer.getNeighborhoodList());
-    var jsonParse = JSON.parse(jsonString)
-    console.log(jsonParse.length + " neighborhoods were successfully queried!")
-    res.json(jsonParse);
+    var result = JSON.parse(JSON.stringify(OperationsLayer.getNeighborhoodList()));
+    console.log(result.length + " neighborhoods were successfully queried!")
+    res.json(result);
 })
 
 router.post('/getFilteredData', (req, res) => {
     console.log("api/getFilteredData call:")
-    //console.log(req.body)
 
     let result = JSON.parse(JSON.stringify(analytics.filterByAll(req.body)))
     console.log(result.length + " neighborhoods were successfully queried!")
@@ -186,6 +183,44 @@ router.get('/column', (req, res) => {
         console.log("api/column GET request was successful")
         res.json(result)
     }
+})
+
+/*
+Function to get the different top 10 values from the different caches
+TODO: split /cache endpoint into 4 separate endpoints, one for each cache
+*/
+router.get('/cache', (req, res) => {
+    console.log("api/cache call:")
+
+    var cacheName = req.query.column;
+    var result;
+
+    switch(cacheName) {
+        case 'highestMedianValue':
+            result = JSON.parse(JSON.stringify(analytics.getHighestMedianValue()))
+            console.log("Got 10 highest median values")
+            break;
+        case 'lowestMedianValue':
+            result = JSON.parse(JSON.stringify(analytics.getLowestMedianValue()))
+            console.log("Got 10 lowest median values")
+            break;
+        case 'closestDistanceToCoast':
+            result = JSON.parse(JSON.stringify(analytics.getClosestDistanceToCoast()))
+            console.log("Got 10 closest distances to coast")
+            break;
+        case 'highestPopulation':
+            result = JSON.parse(JSON.stringify(analytics.getHighestPopulation()))
+            console.log("Got 10 highest populations")
+            break;
+        default:
+            console.warn(`Error while handling GET api/cache with query ${req.query}`)
+            result = {
+                error: "An unknown error has ocurred."
+            }
+            break;
+    }
+
+    res.json(result);
 })
 
 module.exports = router

--- a/server/test/apiTest.js
+++ b/server/test/apiTest.js
@@ -421,3 +421,54 @@ describe("Testing api/column", () => {
             })
     })
 })
+
+describe("Testing api/cache", () => {
+    it("Should receive a list of neighborhoods with the highest median values after GET to /api/cache?highestMedianValue", () => {
+        const params = new URLSearchParams({column: "highestMedianValue"})
+        chai.request("http://localhost:4000")
+            .get(`/api/cache?${params}`)
+            .end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                expect(res.body.length).to.be.equal(10)
+                expect(res.body[0]).to.eql(OperationsLayer.getHighestValueCache()[0])
+                expect(res.body[9]).to.eql(OperationsLayer.getHighestValueCache()[9])
+            })
+    })
+    it("Should receive a list of neighborhoods with the lowest median values after GET to /api/cache?lowestMedianValue", () => {
+        const params = new URLSearchParams({column: "lowestMedianValue"})
+        chai.request("http://localhost:4000")
+            .get(`/api/cache?${params}`)
+            .end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                expect(res.body.length).to.be.equal(10)
+                expect(res.body[0]).to.eql(OperationsLayer.getLowestValueCache()[0])
+                expect(res.body[9]).to.eql(OperationsLayer.getLowestValueCache()[9])
+            })
+    })
+    it("Should receive a list of neighborhoods with the closest distance to the coast after GET to /api/cache?closestDistanceToCoast", () => {
+        const params = new URLSearchParams({column: "closestDistanceToCoast"})
+        chai.request("http://localhost:4000")
+            .get(`/api/cache?${params}`)
+            .end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                expect(res.body.length).to.be.equal(10)
+                expect(res.body[0]).to.eql(OperationsLayer.getClosestCoastCache()[0])
+                expect(res.body[9]).to.eql(OperationsLayer.getClosestCoastCache()[9])
+            })
+    })
+    it("Should receive a list of neighborhoods with the highest populations after GET to /api/cache?highestPopulation", () => {
+        const params = new URLSearchParams({column: "highestPopulation"})
+        chai.request("http://localhost:4000")
+            .get(`/api/cache?${params}`)
+            .end((err, res) => {
+                expect(err).to.be.null
+                expect(res).to.be.json
+                expect(res.body.length).to.be.equal(10)
+                expect(res.body[0]).to.eql(OperationsLayer.getHighestPopulationCache()[0])
+                expect(res.body[9]).to.eql(OperationsLayer.getHighestPopulationCache()[9])
+            })
+    })
+})

--- a/server/test/operationsTest.js
+++ b/server/test/operationsTest.js
@@ -61,15 +61,21 @@ describe("operations.addNeighborhood function", () => {
 });
 
 describe("operations.updateNeighborhood function", () => {
-	validNeighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106, 9];
+    //var NeighborhoodCopy = JSON.parse(JSON.stringify(OperationsLayer.getNeighborhoodList()[8]))
+	//validNeighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106, 9];
     invalidNeighborhoodData = [360000, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106, -1];
+    updateCode = OperationsLayer.updateNeighborhood([360000,5.6431,52,1274,235,30000,219,37.85,-122.25,7768.086571,555194.2661,734095.2907,65287.13841,18031.04757,4])
+    newMedianValue = OperationsLayer.getNeighborhoodList().at(3).median_value;
+    //OperationsLayer.updateNeighborhood(NeighborhoodCopy) //reset the data
+    //Reset data
+    OperationsLayer.updateNeighborhood([341300,5.6431,52,1274,235,558,219,37.85,-122.25,7768.086571,555194.2661,734095.2907,65287.13841,18031.04757,4])
 
     it("Should update the neighborhood with the specified data and id in neighborhoodList", () => {
-        expect(OperationsLayer.updateNeighborhood(validNeighborhoodData)).to.be.equal(0);
+        expect(updateCode).to.be.equal(0);
     })
     it("Should read the correct values for the updated neighborhood", () => {
-        expect(OperationsLayer.getNeighborhoodList().at(8).median_value).to.be.equal(360000);
-        expect(OperationsLayer.getNeighborhoodList().at(8).id).to.be.equal(9);
+        expect(newMedianValue).to.be.equal(360000);
+        expect(OperationsLayer.getNeighborhoodList().at(3).id).to.be.equal(4);
     })
     it("Should fail if we attempt to update a neighborhood with an invalid id", () => {
         expect(OperationsLayer.updateNeighborhood(invalidNeighborhoodData)).to.be.equal(-1);
@@ -77,17 +83,42 @@ describe("operations.updateNeighborhood function", () => {
 });
 
 describe("testing creating caches", () =>{
-
     it("Should return the highest median value of 500001", () => {
-        expect(parseInt(OperationsLayer.getHighMedianCache()[0].median_value)).to.be.equal(500001);
+        expect(parseInt(OperationsLayer.getHighestValueCache()[0].median_value)).to.be.equal(500001);
     })   
     it("Should return the lowest median value of 14999", () => {
-        expect(parseInt(OperationsLayer.getLowMedianCache()[0].median_value)).to.be.equal(14999);
+        expect(parseInt(OperationsLayer.getLowestValueCache()[0].median_value)).to.be.equal(14999);
     })
     it("Should return the shortest distance to coast of 120.....", () => {
-        expect(parseFloat(OperationsLayer.getClosestCoast()[0].distance_to_coast)).to.be.equal(120.6764466);
+        expect(parseFloat(OperationsLayer.getClosestCoastCache()[0].distance_to_coast)).to.be.equal(120.6764466);
     })
     it("Should return the highest population of 35682", () => {
-        expect(parseInt(OperationsLayer.getHighestPop()[0].population)).to.be.equal(35682);
+        expect(parseInt(OperationsLayer.getHighestPopulationCache()[0].population)).to.be.equal(35682);
+        expect(parseInt(OperationsLayer.getHighestPopulationCache()[1].population)).to.be.equal(28566);
     })
 })
+
+describe("testing updating caches", () =>{
+    let neighborhoodData = [500002, 50000, 50, 3000, 1000, 30000, 2000, 38, -122, 4206.81187, 544221.0324, 723064.4512, 53978.76396, 21266.94106];
+    OperationsLayer.addNeighborhood(neighborhoodData); // Add a neighborhood to neighborhoodList to delete later
+    let lastID = OperationsLayer.getNeighborhoodList().at(-1).id;
+    let highestValueBeforeDelete = OperationsLayer.getHighestValueCache()[0].median_value; // Length of the neighborhoodList before a row is deleted
+    OperationsLayer.deleteNeighborhood(lastID); // Delete the last neighborhood
+    let highestValueAfterDelete = OperationsLayer.getHighestValueCache()[0].median_value;  // Length of the neighborhoodList after a row is deleted
+
+    OperationsLayer.updateNeighborhood([500003,5.6431,52,1274,235,558,219,37.85,-122.25,7768.086571,555194.2661,734095.2907,65287.13841,18031.04757, 4])
+    let highestValueAfterUpdate = OperationsLayer.getHighestValueCache()[0].median_value;
+    //Reset data
+    OperationsLayer.updateNeighborhood([341300,5.6431,52,1274,235,558,219,37.85,-122.25,7768.086571,555194.2661,734095.2907,65287.13841,18031.04757, 4])
+
+    it("Should return the new highest median value of 500002", () => {
+        expect(parseInt(highestValueBeforeDelete)).to.be.equal(500002);
+    }) 
+    it("Should return the previous highest median value of 500001", () => {
+        expect(parseInt(highestValueAfterDelete)).to.be.equal(500001);
+    }) 
+    it("Should update cache and return highest median value of 500003", () => {
+        expect(parseInt(highestValueAfterUpdate)).to.be.equal(500003);
+    }) 
+})
+


### PR DESCRIPTION
## Major Changes

A new "factoids" page has been added, containing 4 top 10 columns. I've added client-side asynchronous calls to each, with the endpoint as `/api/cache`, type as **GET**, and query as `column`.

This also introduces a pretty significant change to the "Cards" class in general, with a new prop that is required to be passed in that changes the visibility of the edit arrow (though the box itself is also still present, it is hidden and can't be "opened" by conventional means)

Attached is the mock API endpoint implementation used to test functionality:
![image](https://user-images.githubusercontent.com/13594022/168505590-e9ba3242-098a-41fe-9aad-a6fb670d6737.png)

Fixes #79 

## Minor Changes

I decided to get slightly ahead of next week's sprint and put the first draft of a CSS facelift in terms of coloring. Nothing spectacular, and I'd like to get some feedback. Still very much plain, but at least a bit more colorful than before.

![image](https://user-images.githubusercontent.com/13594022/168505506-147c55fd-9302-44df-acfe-6ebd7a6e4732.png)
